### PR TITLE
Ulo/dls this year data only #64

### DIFF
--- a/pages/ULO.py
+++ b/pages/ULO.py
@@ -390,8 +390,9 @@ def selectULO(SelDiv, SelDis, SelUpa, SelDiseases, sdate, edate):
             bahis_data[['division', 'district', 'species_no']]=bahis_data[['division', 'district', 'species_no']].astype(np.uint16)   
             bahis_data[['upazila', 'sick', 'dead']]=bahis_data[['upazila',  'sick', 'dead']].astype(np.int32)
             bahis_data['dead'] = bahis_data['dead'].clip(lower=0)
-            maxdates=[min(bahis_data['date']),max(bahis_data['date'])] 
-            bahis_data=bahis_data[bahis_data['date'].dt.date>= maxdates[1]-relativedelta(months=12)] #datetime(2019, 7, 1)]
+#            maxdates=[min(bahis_data['date']),max(bahis_data['date'])] 
+#            bahis_data=bahis_data[bahis_data['date'].dt.date>= maxdates[1]-relativedelta(months=12)] #datetime(2019, 7, 1)]
+            bahis_data=bahis_data[bahis_data['date'].dt.year== max(bahis_data['date']).year]
             maxdates=[min(bahis_data['date']),max(bahis_data['date'])] 
             disabSelDate=False
             minSelDate=maxdates[0]

--- a/pages/dls.py
+++ b/pages/dls.py
@@ -65,7 +65,8 @@ def fetchsourcedata(): #fetch and prepare source data
     bahis_data[['upazila', 'sick', 'dead']]=bahis_data[['upazila',  'sick', 'dead']].astype(np.int32) #converting into uint makes odd values)
 #    bahis_data[['species', 'tentative_diagnosis', 'top_diagnosis']]=bahis_data[['species', 'tentative_diagnosis', 'top_diagnosis']].astype(str) # can you change object to string and does it make a memory difference`?
     bahis_data['dead'] = bahis_data['dead'].clip(lower=0)
-    bahis_data=bahis_data[bahis_data['date']>=datetime(2019, 7, 1)]
+#    bahis_data=bahis_data[bahis_data['date']>=datetime(2019, 7, 1)]
+    bahis_data=bahis_data[bahis_data['date'].dt.year== max(bahis_data['date']).year]
     return bahis_data
 bahis_data=fetchsourcedata() 
 sub_bahis_sourcedata=bahis_data
@@ -322,11 +323,11 @@ layout =  html.Div([
                             dcc.DatePickerRange(
                                     id='daterange',
                                     min_date_allowed=start_date,
-                                    start_date=date(2022, 1, 1) ,
+                                    start_date=date(2023, 1, 1) ,
                                     max_date_allowed=end_date,
                                     # start_date=date(end_date.year-1, end_date.month, end_date.day),
                                     # initial_visible_month=end_date,
-                                    end_date=date(2022, 12, 31)
+                                    end_date=date(2023, 12, 31)
                                     #end_date=end_date
                                 ),
                             ]),


### PR DESCRIPTION
In order to accelerate the page loading, one strategy was pursued to reduce data file size. All data not coming from the current year are being excluded in both tabs ulo.py and dls.py during first loading.
For some analysis, this reduction excludes necessary data, so this has to be addressed in a different issue.

The database itself is not changed, it is preprocessing data for the dashboard.

- [ ] I have read the road86 Contribution Guide.
- [ ] I have checked all commit message styles match the requested structure.
- [ ] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] New database changes have been committed.
