### PR TITLE
fix: monthly comparison renamed to yearly comparison

### DIFF
--- a/components/yearly_comparison.py
+++ b/components/yearly_comparison.py
@@ -1,0 +1,21 @@
+import plotly.express as px
+from dash import dcc
+
+
+def yearlyComp(bahis_data):
+    monthly = bahis_data.groupby(
+            [bahis_data["date"].dt.year.rename("year"), bahis_data["date"].dt.month.rename("month")]
+        )["date"].agg({"count"})
+    monthly = monthly.rename({"count": "reports"}, axis=1)
+    monthly = monthly.reset_index()
+    monthly["year"] = monthly["year"].astype(str)
+    figYearlyComp = px.bar(
+                    data_frame=monthly,
+                    x="month",
+                    y="reports",
+                    labels={"month": "", "reports": "Reports"},
+                    color="year",
+                    barmode="group",
+    )
+    figYearlyComp.update_xaxes(dtick="M1", tickformat="%b\n%Y")
+    return figYearlyComp

--- a/pages/dls.py
+++ b/pages/dls.py
@@ -13,6 +13,7 @@ from dash import callback, ctx, dash_table, dcc, html
 from dash.dash import no_update
 from dash.dependencies import Input, Output, State
 from plotly.subplots import make_subplots
+from components import yearly_comparison
 
 starttime_start = datetime.now()
 
@@ -942,8 +943,8 @@ layout = html.Div(
                                         ),
                                         dbc.Tab(
                                             [dbc.Card(dbc.Col([dcc.Graph(id="figMonthly")]))],
-                                            label="Monthly Comparison",
-                                            tab_id="MonthCompTab",
+                                            label="Yearly Comparison",
+                                            tab_id="YearCompTab",
                                         ),
                                         dbc.Tab(
                                             [
@@ -1589,24 +1590,10 @@ def update_whatever(
 
     # tab 5 monthly currently not geo resolved and disease, because of bahis_data, either ata is time restricted or
 
-    if tabs == "MonthCompTab":
+    if tabs == "YearCompTab":
         starttime_tab5 = datetime.now()
 
-        monthly = bahis_data.groupby(
-            [bahis_data["date"].dt.year.rename("year"), bahis_data["date"].dt.month.rename("month")]
-        )["date"].agg({"count"})
-        monthly = monthly.rename({"count": "reports"}, axis=1)
-        monthly = monthly.reset_index()
-        monthly["year"] = monthly["year"].astype(str)
-        figMonthly = px.bar(
-            data_frame=monthly,
-            x="month",
-            y="reports",
-            labels={"month": "Month", "reports": "Reports"},
-            color="year",
-            barmode="group",
-        )
-        figMonthly.update_xaxes(dtick="M1", tickformat="%B")
+        figMonthly = yearly_comparison.yearlyComp(bahis_data)
 
         endtime_tab5 = datetime.now()
         print("tab5 : " + str(endtime_tab5 - starttime_tab5))


### PR DESCRIPTION
## Description

Monthly comparison tab has been renamed to "Yearly comparison". A new file was added to components folder to which contains the functions of the Yearly Comparison tab.


closes #120 

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request). If you're unsure about any of these, don't hesitate to leave a comment on this pull request!

- [X] I have read the road86 Contribution Guide.
- [X] I have checked all commit message styles match the requested structure.
- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have assigned at least one reviewer.
- [] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [X] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] New database changes have been committed.
