### PR TITLE
fix: monthly names and thousand k in yearly

### DIFF
--- a/components/CompletenessReport.py
+++ b/components/CompletenessReport.py
@@ -5,13 +5,10 @@ import pandas as pd
 def find_weeks(start, end):
     list_of_weeks = []
     days_to_thursday = (3 - start.weekday()) % 7
-    print(days_to_thursday)
     for i in range((end - start).days + 1):
         d = (start + timedelta(days=i)).isocalendar()[:2]  # e.g. (2011, 52)
-        print(d)
         yearweek = "y{}w{:02}".format(*d)  # e.g. "201152"
         list_of_weeks.append(yearweek)
-    print(sorted(set(list_of_weeks)))
     return sorted(set(list_of_weeks))
 
 

--- a/components/yearly_comparison.py
+++ b/components/yearly_comparison.py
@@ -16,5 +16,5 @@ def yearlyComp(bahis_data):
         color="year",
         barmode="group",
     )
-    figYearlyComp.update_xaxes(dtick="M1", tickformat="%b\n%Y")
+    figYearlyComp.update_xaxes(dtick="M1", tickformat="%B \n%Y")
     return figYearlyComp

--- a/components/yearly_comparison.py
+++ b/components/yearly_comparison.py
@@ -7,12 +7,13 @@ def yearlyComp(bahis_data):
     )["date"].agg({"count"})
     monthly = monthly.rename({"count": "reports"}, axis=1)
     monthly = monthly.reset_index()
+    monthly['reports'] = monthly['reports'] / 1000
     monthly["Year"] = monthly["Year"].astype(str)
     figYearlyComp = px.bar(
         data_frame=monthly,
         x="Month",
         y="reports",
-        labels={"Month": "Month", "reports": "Reports"},
+        labels={"Month": "Month", "reports": "Reports in Thousands"},
         color="Year",
         barmode="group",
     )

--- a/components/yearly_comparison.py
+++ b/components/yearly_comparison.py
@@ -3,18 +3,26 @@ import plotly.express as px
 
 def yearlyComp(bahis_data):
     monthly = bahis_data.groupby(
-        [bahis_data["date"].dt.year.rename("year"), bahis_data["date"].dt.month.rename("month")]
+        [bahis_data["date"].dt.year.rename("Year"), bahis_data["date"].dt.month.rename("Month")]
     )["date"].agg({"count"})
     monthly = monthly.rename({"count": "reports"}, axis=1)
     monthly = monthly.reset_index()
-    monthly["year"] = monthly["year"].astype(str)
+    monthly["Year"] = monthly["Year"].astype(str)
     figYearlyComp = px.bar(
         data_frame=monthly,
-        x="month",
+        x="Month",
         y="reports",
-        labels={"month": "", "reports": "Reports"},
-        color="year",
+        labels={"Month": "Month", "reports": "Reports"},
+        color="Year",
         barmode="group",
     )
-    figYearlyComp.update_xaxes(dtick="M1", tickformat="%B \n%Y")
+    figYearlyComp.update_xaxes(dtick="M1")  # , tickformat="%B \n%Y")
+    figYearlyComp.update_layout(
+        xaxis=dict(
+            tickmode='array',
+            tickvals=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+            ticktext=['January', 'February', 'March', 'April', 'May', 'June',
+                      'July', 'August', 'September', 'October', 'November', 'December']
+        )
+    )
     return figYearlyComp


### PR DESCRIPTION
## Description

replaced numbers for months with names in yearly comparison.
got rid of thousands k and put "Thousands" in label

Don't forget to reference all other pull requests which are associated to this one below: e.g.

closes #119 
relates road86/repository_name#issue_number

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request). If you're unsure about any of these, don't hesitate to leave a comment on this pull request!

- [ ] I have read the road86 Contribution Guide.
- [ ] I have checked all commit message styles match the requested structure.
- [ ] My code follows the style guidelines of this project.
- [x ] I have performed a self-review of my own code.
- [x ] I have assigned at least one reviewer.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x ] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] New database changes have been committed.
