### PR TITLE
fix: mislead links for farm assessment

### DIFF
--- a/components/navbar.py
+++ b/components/navbar.py
@@ -38,15 +38,23 @@ def Navbar(aid):
                     [
                         dbc.Nav(
                             [
-                                dbc.NavLink("Antibiotics Usage Poultry", href="/completeness", active="exact"),
-                                dbc.NavLink("Antibiotics Usage Report AWaRe", href="/completeness", active="exact"),
-                                dbc.NavLink("Antibiotics Class", href="/completeness", active="exact"),
-                                dbc.NavLink("Biosecurity at entrance", href="/bsentrance", active="exact"),
+                                dbc.NavLink("Antibiotics Usage Poultry", href="/todopage/?aid=" + aid, active="exact"),
                                 dbc.NavLink(
-                                    "Biosecurity between loading and production", href="/bsproduction", active="exact"
+                                    "Antibiotics Usage Report AWaRe", href="/todopage/?aid=" + aid, active="exact"
                                 ),
-                                dbc.NavLink("Biosecurity personell management", href="/bspersonell", active="exact"),
-                                dbc.NavLink("Biosecurity equipment management", href="/bsequipment", active="exact"),
+                                dbc.NavLink("Antibiotics Class", href="/todopage/?aid=" + aid, active="exact"),
+                                dbc.NavLink("Biosecurity at entrance", href="/bsentrance/?aid=" + aid, active="exact"),
+                                dbc.NavLink(
+                                    "Biosecurity between loading and production",
+                                    href="/bsproduction/?aid=" + aid,
+                                    active="exact",
+                                ),
+                                dbc.NavLink(
+                                    "Biosecurity personell management", href="/bspersonell/?aid=" + aid, active="exact"
+                                ),
+                                dbc.NavLink(
+                                    "Biosecurity equipment management", href="/bsequipment/?aid=" + aid, active="exact"
+                                ),
                             ],
                             vertical=True,
                             pills=True,

--- a/pages/todopage.py
+++ b/pages/todopage.py
@@ -1,0 +1,6 @@
+import dash
+from dash import html
+
+dash.register_page(__name__)
+
+layout = html.H2("This page is under development.")


### PR DESCRIPTION
## Description

fixes mislead farm assessment links.
created a "under development" page

Don't forget to reference all other pull requests which are associated to this one below: e.g.

closes  #216
relates road86/repository_name#issue_number


## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request). If you're unsure about any of these, don't hesitate to leave a comment on this pull request!

- [ ] I have read the road86 Contribution Guide.
- [ ] I have checked all commit message styles match the requested structure.
- [ ] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] New database changes have been committed.
